### PR TITLE
Specify named arguments for PyTorchModel in test_mnist

### DIFF
--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -48,8 +48,8 @@ def _test_mnist_distributed(sagemaker_session, ecr_image, instance_type):
     pytorch = PyTorchModel(model_data,
                            'SageMakerRole',
                            mnist_script,
-                           ecr_image,
-                           sagemaker_session)
+                           image=ecr_image,
+                           sagemaker_session=sagemaker_session)
 
     with timeout_and_delete_endpoint(endpoint_name, sagemaker_session, minutes=30):
         predictor = pytorch.deploy(initial_instance_count=1, instance_type=instance_type,


### PR DESCRIPTION
*Issue #, if available:*

1. Specify named argument for image and sagemaker_session for PyTorchModel, else it fails with:
```
 botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the CreateModel operation: Region of "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.2.0-gpu-py2" does not match expected region of us-east-1. Cross region ECR image pulls are not allowed.
```
2. The sagemaker_session parameter was used in place of where the py_version was being expected, as shown here: https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/pytorch/model.py#L63

Test Results
```
[ec2-user@ip-172-31-30-85 sagemaker-pytorch-serving-container]$ pytest test/integration/sagemaker/test_mnist.py --aws-id 763104351884 --region us-west-2 --docker-base-name pytorch-inference --instance-type ml.p2.xlarge --framework-version 1.2.0 --processor gpu --py-version 2
============================================================ test session starts ============================================================
platform linux -- Python 3.6.8, pytest-4.4.1, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/ec2-user/sagemaker-pytorch-serving-container, inifile: setup.cfg
plugins: rerunfailures-7.0, forked-1.0.2, xdist-1.28.0, cov-2.7.1, requests-mock-1.6.0
collected 2 items                                                                                                                           

test/integration/sagemaker/test_mnist.py::test_mnist_distributed_cpu SKIPPED                                                          [ 50%]
test/integration/sagemaker/test_mnist.py::test_mnist_distributed_gpu PASSED                                                           [100%]

=================================================== 1 passed, 1 skipped in 686.71 seconds ===================================================
[ec2-user@ip-172-31-30-85 sagemaker-pytorch-serving-container]$ 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
