### PR TITLE
change: bump mms and inference-toolkit versions

### DIFF
--- a/docker/1.2.0/py2/Dockerfile.cpu
+++ b/docker/1.2.0/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -43,7 +44,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 ARG PYTORCH_VERSION=1.2.0
 ARG TORCHVISION_VERSION=0.4.0
-ARG MMS_VERSION=1.0.7
+ARG MMS_VERSION=1.0.8
 RUN conda install -c conda-forge awscli==1.16.210 opencv==4.0.1 && \
     conda install -y scikit-learn==0.20.3 \
                      pandas==0.24.2 \

--- a/docker/1.2.0/py3/Dockerfile.cpu
+++ b/docker/1.2.0/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -43,7 +44,7 @@ ENV PATH /opt/conda/bin:$PATH
 
 ARG PYTORCH_VERSION=1.2.0
 ARG TORCHVISION_VERSION=0.4.0
-ARG MMS_VERSION=1.0.7
+ARG MMS_VERSION=1.0.8
 RUN conda install -c conda-forge awscli==1.16.210 opencv==4.0.1 && \
     conda install -y scikit-learn==0.21.2 \
                      pandas==0.25.0 \

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['numpy==1.16.4', 'Pillow==6.2.0', 'retrying==1.3.3', 'sagemaker-containers==2.5.4',
-                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.1',
+                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
                       'retrying==1.3.3'],
     extras_require={
         'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['numpy==1.16.4', 'Pillow==6.2.0', 'retrying==1.3.3', 'sagemaker-containers==2.5.4',
-                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.0',
+                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.1',
                       'retrying==1.3.3'],
     extras_require={
         'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- bump mms version to 1.0.8
- bump sagemaker-inference-toolkit version to 1.1.2
- add label to dockerfiles


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
