### PR TITLE
change: bump inference-toolkit version and add mme label

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    FRAMEWORK_VERSION: '1.2.0'
+    FRAMEWORK_VERSION: '1.3.1'
     CPU_PY2_VERSION: '2'
     CPU_PY3_VERSION: '3'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'

--- a/docker/1.3.1/py2/Dockerfile.cpu
+++ b/docker/1.3.1/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=2.7
 ARG PYTORCH_VERSION=1.3.1

--- a/docker/1.3.1/py3/Dockerfile.cpu
+++ b/docker/1.3.1/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=3.6.6
 ARG PYTORCH_VERSION=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,12 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['numpy==1.16.4', 'Pillow==6.2.0', 'retrying==1.3.3', 'sagemaker-containers==2.5.4',
-                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.0',
+                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
                       'retrying==1.3.3'],
     extras_require={
         'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',
-                 'sagemaker==1.38.5', 'requests==2.20.0', 'torchvision==0.4.0', 'tox==3.7.0', 'requests_mock==1.6.0']
+                 'sagemaker==1.38.5', 'requests==2.20.0', 'torchvision==0.4.1', 'tox==3.7.0', 'requests_mock==1.6.0']
     },
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -47,12 +47,12 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['numpy==1.16.4', 'Pillow==6.2.0', 'retrying==1.3.3', 'sagemaker-containers==2.5.4',
-                      'six==1.12.0', 'torch==1.2.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
+                      'six==1.12.0', 'torch==1.3.1', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
                       'retrying==1.3.3'],
     extras_require={
         'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',
-                 'sagemaker==1.38.5', 'requests==2.20.0', 'torchvision==0.4.1', 'tox==3.7.0', 'requests_mock==1.6.0']
+                 'sagemaker==1.38.5', 'requests==2.20.0', 'torchvision==0.4.2', 'tox==3.7.0', 'requests_mock==1.6.0']
     },
 
     entry_points={


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- bump sagemaker-inference-toolkit version to 1.1.2
- add mme capability label to 1.3.1 dockerfiles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
