### PR TITLE
Add LABEL for port bind to 1.2.0 and 1.3.1 dockerfiles

### DIFF
--- a/docker/1.2.0/py2/Dockerfile.cpu
+++ b/docker/1.2.0/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/docker/1.2.0/py2/Dockerfile.gpu
+++ b/docker/1.2.0/py2/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 # NCCL_VERSION=2.4.7, CUDNN_VERSION=7.6.2.24
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN apt-get update && apt-get install -y  --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \

--- a/docker/1.2.0/py3/Dockerfile.cpu
+++ b/docker/1.2.0/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/docker/1.2.0/py3/Dockerfile.gpu
+++ b/docker/1.2.0/py3/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 # NCCL_VERSION=2.4.7, CUDNN_VERSION=7.6.2.24
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 RUN apt-get update && apt-get install -y  --allow-downgrades --allow-change-held-packages --no-install-recommends \
         build-essential \

--- a/docker/1.3.1/py2/Dockerfile.cpu
+++ b/docker/1.3.1/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=2.7

--- a/docker/1.3.1/py2/Dockerfile.gpu
+++ b/docker/1.3.1/py2/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04
 # NCCL_VERSION=2.4.7, CUDNN_VERSION=7.6.2.24
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG PYTHON_VERSION=2.7
 ARG PYTORCH_VERSION=1.3.1

--- a/docker/1.3.1/py3/Dockerfile.cpu
+++ b/docker/1.3.1/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=3.6.6

--- a/docker/1.3.1/py3/Dockerfile.gpu
+++ b/docker/1.3.1/py3/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04
 # NCCL_VERSION=2.4.7, CUDNN_VERSION=7.6.2.24
 LABEL maintainer="Amazon AI"
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 # Add arguments to achieve the version, python and url
 ARG PYTHON_VERSION=3.6.6


### PR DESCRIPTION
*Description of changes:*
Dockerfiles for PyTorch Serving 1.2.0 and 1.3.1 were missing LABEL to accept sagemaker bind-to-port capability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
