### PR TITLE
change: upgrade sagemaker to 1.48.0 for test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     extras_require={
         'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',
-                 'sagemaker==1.38.5', 'requests==2.20.0', 'torchvision==0.4.2', 'tox==3.7.0', 'requests_mock==1.6.0']
+                 'sagemaker==1.48.0', 'requests==2.20.0', 'torchvision==0.4.2', 'tox==3.7.0', 'requests_mock==1.6.0']
     },
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                       'six==1.12.0', 'torch==1.3.1', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
                       'retrying==1.3.3'],
     extras_require={
-        'test': ['boto3==1.9.213', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
+        'test': ['boto3==1.10.32', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',
                  'sagemaker==1.48.0', 'requests==2.20.0', 'torchvision==0.4.2', 'tox==3.7.0', 'requests_mock==1.6.0']
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`PyTorch.LATEST_VERSION` has been updated, so upgrading the library dependency here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
