### PR TITLE
change: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+test/resources/local_mode_lock
+.tox/
+.coverage
+*.egg-info/
+__pycache__/
 .idea/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 test/resources/local_mode_lock
 .tox/
 .coverage


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`test/resources/local_mode_lock` is specific to our integ tests, `.tox/` and `.coverage` are for our tox stuff, and `*.egg-info/` and `__pycache__/` are Python-specific. The two existing entries are actually not project-specific and should be in a person's global gitignore if it applies to them (i.e. if they use a Mac and/or an IDEA product), but I thought it would be easier to just leave them alone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
