### PR TITLE
change: undo upgrade mms version and library name

### DIFF
--- a/docker/1.4.0/py3/Dockerfile.cpu
+++ b/docker/1.4.0/py3/Dockerfile.cpu
@@ -6,7 +6,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 ARG PYTHON_VERSION=3.6.6
 ARG PYTORCH_VERSION=1.4.0
 ARG TORCHVISION_VERSION=0.5.0
-ARG MMS_VERSION=1.1.0
+ARG MMS_VERSION=1.0.8
 
 # See http://bugs.python.org/issue19846
 ENV LANG C.UTF-8
@@ -64,7 +64,7 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install multi-model-server==$MMS_VERSION
+ && pip install mxnet-model-server==$MMS_VERSION
 
 RUN useradd -m model-server \
  && mkdir -p /home/model-server/tmp \
@@ -84,4 +84,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.4.0/license.txt -o 
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/docker/1.4.0/py3/Dockerfile.gpu
+++ b/docker/1.4.0/py3/Dockerfile.gpu
@@ -7,7 +7,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 ARG PYTHON_VERSION=3.6.6
 ARG PYTORCH_VERSION=1.4.0
 ARG TORCHVISION_VERSION=0.5.0
-ARG MMS_VERSION=1.1.0
+ARG MMS_VERSION=1.0.8
 
 # See http://bugs.python.org/issue19846
 ENV LANG C.UTF-8
@@ -82,7 +82,7 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install multi-model-server==$MMS_VERSION
+ && pip install mxnet-model-server==$MMS_VERSION
 
 RUN useradd -m model-server \
  && mkdir -p /home/model-server/tmp \
@@ -102,4 +102,4 @@ RUN curl https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.4.0/license.txt -o 
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
-CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]
+CMD ["mxnet-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -194,7 +194,8 @@ def skip_gpu_instance_restricted_regions(region, instance_type):
 
 
 @pytest.fixture(autouse=True)
-def skip_gpu_py2(request, use_gpu, instance_type, py_version):
+def skip_gpu_py2(request, use_gpu, instance_type, py_version, framework_version):
     is_gpu = use_gpu or instance_type[3] in ['g', 'p']
-    if request.node.get_closest_marker('skip_gpu_py2') and is_gpu and py_version != 'py3':
+    if request.node.get_closest_marker('skip_gpu_py2') and is_gpu and py_version != 'py3' \
+            and framework_version == '1.4.0':
         pytest.skip('Skipping the test until mms issue resolved.')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
skip the model_fn_called_once only for 1.4.0 gpu py2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
