### PR TITLE
Upgrade the version of sagemaker-inference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     install_requires=['numpy==1.16.4', 'Pillow==6.2.0', 'retrying==1.3.3', 'sagemaker-containers==2.5.4',
-                      'six==1.12.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.1.2',
+                      'six==1.12.0', 'requests_mock==1.6.0', 'sagemaker-inference==1.2.0',
                       'retrying==1.3.3'],
     extras_require={
         'test': ['boto3==1.10.32', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',


### PR DESCRIPTION
Upgrade to the latest version of sagemaker-inference: https://github.com/aws/sagemaker-inference-toolkit/releases/tag/v1.2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
