### PR TITLE
Change miniconda installation in dockerfiles

### DIFF
--- a/docker/1.3.1/py3/Dockerfile.eia
+++ b/docker/1.3.1/py3/Dockerfile.eia
@@ -46,8 +46,7 @@ RUN apt-get install -y --no-install-recommends \
  && echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new \
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_configs
 
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
- && mv Miniconda3-latest-Linux-x86_64.sh ~/miniconda.sh \
+RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \

--- a/docker/1.3.1/py3/Dockerfile.eia
+++ b/docker/1.3.1/py3/Dockerfile.eia
@@ -46,7 +46,8 @@ RUN apt-get install -y --no-install-recommends \
  && echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new \
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_configs
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+ && mv Miniconda3-latest-Linux-x86_64.sh ~/miniconda.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \

--- a/docker/1.4.0/py2/Dockerfile.cpu
+++ b/docker/1.4.0/py2/Dockerfile.cpu
@@ -35,7 +35,7 @@ RUN apt-get update \
     zlib1g-dev
 
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \

--- a/docker/1.4.0/py2/Dockerfile.gpu
+++ b/docker/1.4.0/py2/Dockerfile.gpu
@@ -44,7 +44,7 @@ RUN apt-get install -y --no-install-recommends \
  && echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new \
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  \
+RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \

--- a/docker/1.4.0/py3/Dockerfile.cpu
+++ b/docker/1.4.0/py3/Dockerfile.cpu
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     zlib1g-dev 
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  \
+RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \

--- a/docker/1.4.0/py3/Dockerfile.gpu
+++ b/docker/1.4.0/py3/Dockerfile.gpu
@@ -45,7 +45,7 @@ RUN apt-get install -y --no-install-recommends \
  && echo "    StrictHostKeyChecking no" >> /etc/ssh/ssh_config.new \
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_configs
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
  && chmod +x ~/miniconda.sh \
  && ~/miniconda.sh -b -p /opt/conda \
  && rm ~/miniconda.sh \


### PR DESCRIPTION
*Description of changes:*
The line
```
curl -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
```
doesn't work anymore after a change in the way the file is hosted at that URL around April 07, 2020.

Therefore this curl command has been replaced with
```
curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
```
with `curl -L` to allow the link to be redirected to the actual download link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
