### PR TITLE
Load EI model to CPU by default in model_fn

### DIFF
--- a/src/sagemaker_pytorch_serving_container/default_inference_handler.py
+++ b/src/sagemaker_pytorch_serving_container/default_inference_handler.py
@@ -39,7 +39,8 @@ class DefaultPytorchInferenceHandler(default_inference_handler.DefaultInferenceH
             if not os.path.exists(model_path):
                 raise FileNotFoundError("Failed to load model with default model_fn: missing file {}."
                                         .format(DEFAULT_MODEL_FILENAME))
-            return torch.jit.load(model_path)
+            # Client-framework is CPU only. But model will run in Elastic Inference server with CUDA.
+            return torch.jit.load(model_path, map_location=torch.device('cpu'))
         else:
             raise NotImplementedError(textwrap.dedent("""
             Please provide a model_fn implementation.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since the EI-enabled client framework is CPU only, we will load PyTorch models to CPU by default when the user is using Elastic Inference. The model still runs on the server in CUDA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
