### PR TITLE
Fixed handler service to allow running custom user modules in multi-m…

### DIFF
--- a/src/sagemaker_pytorch_serving_container/handler_service.py
+++ b/src/sagemaker_pytorch_serving_container/handler_service.py
@@ -22,7 +22,9 @@ import sys
 
 ENABLE_MULTI_MODEL = os.getenv("SAGEMAKER_MULTI_MODEL", "false") == "true"
 
+
 class HandlerService(DefaultHandlerService):
+
     """Handler service that is executed by the model server.
 
     Determines specific default inference handlers to use based on the type MXNet model being used.
@@ -36,17 +38,15 @@ class HandlerService(DefaultHandlerService):
     """
     def __init__(self):
         self._initialized = False
-        
+
         transformer = Transformer(default_inference_handler=DefaultPytorchInferenceHandler())
         super(HandlerService, self).__init__(transformer=transformer)
 
-        
     def initialize(self, context):
-        
         # Adding the 'code' directory path to sys.path to allow importing user modules when multi-model mode is enabled.
         if (not self._initialized) and ENABLE_MULTI_MODEL:
             code_dir = os.path.join(context.system_properties.get("model_dir"), 'code')
             sys.path.append(code_dir)
             self._initialized = True
-        
+
         super().initialize(context)


### PR DESCRIPTION
…odel mode.

*Issue #, if available:*

*Description of changes:*
I have fixed the handler service to allow including the 'code' dir (where user modules are stored) to the Python path. This is required for importing the custom user modules when the container is used in multi-model mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
