### PR TITLE
feature: Python 3.7 support

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py36 -- test/unit
+        tox -e py36,py37 -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec-toolkit.yml
+++ b/buildspec-toolkit.yml
@@ -33,7 +33,7 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py36 test-toolkit/unit
+      - tox -e py36,py37 test-toolkit/unit
 
       # define tags
       - GENERIC_TAG="$FRAMEWORK_VERSION-pytorch-$BUILD_ID"

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,12 @@ setup(
         "Programming Language :: Python",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
-    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.2.2'],
+    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1'],
     extras_require={
         'test': ['boto3==1.10.32', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,flake8
+envlist = flake8,py36,py37
 skip_missing_interpreters = False
 
 [flake8]


### PR DESCRIPTION
*Description of changes:*
- Upgrade version of sagemaker-inference to `1.3.1`, which supports Python 3.7.
- Update tox and buildspecs to test against py37.
- Update Python version in `setup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
